### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Html/ElementTest.php
+++ b/tests/Html/ElementTest.php
@@ -16,7 +16,7 @@ class ElementTest extends TestCase
     /** @var ElementInterface */
     private $element;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dom = Mockery::mock(\DOMElement::class);
         $this->element = new Element($this->dom);

--- a/tests/Html/ParserTest.php
+++ b/tests/Html/ParserTest.php
@@ -11,7 +11,7 @@ class ParserTest extends TestCase
 {
     private $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parser = new Parser(<<<HTML
 <html>

--- a/tests/Xml/ParserTest.php
+++ b/tests/Xml/ParserTest.php
@@ -12,7 +12,7 @@ class ParserTest extends TestCase
 {
     private $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parser = new Parser(<<<XML
 <document>


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.